### PR TITLE
Fix footer display issues

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,10 @@ body {
   margin: 0;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background: #ffffff;
-  color: #ffffff;
+  color: #05071f;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 .hero {
@@ -182,10 +185,16 @@ body {
 
 /* Site-wide footer */
 
+main {
+  flex: 1;
+}
+
 .site-footer {
   text-align: center;
   padding: 24px;
   font-size: 1rem;
   font-weight: 600;
   color: #3d3580;
+  background: #ece9ff;
+  border-top: 1px solid #d4cefc;
 }


### PR DESCRIPTION
## Problem
The site footer was not displaying correctly due to three issues in `styles.css`:

1. **White-on-white body text** — `body { color: #ffffff }` on a white background made inherited text invisible. The footer overrode this with its own colour, but the root cause needed fixing.
2. **No sticky footer layout** — The footer floated up from the bottom of the viewport on short-content pages (no `min-height: 100vh` + flex layout).
3. **No visual separation** — The footer blended into the white page with no background or border.

## Changes
- Fixed `body` text colour from `#ffffff` → `#05071f`
- Added `display: flex; flex-direction: column; min-height: 100vh` to `body` and `flex: 1` to `main` for sticky footer behaviour
- Added `background: #ece9ff` and `border-top: 1px solid #d4cefc` to `.site-footer` for visual distinction