### PR TITLE
Update homepage subtitle, add blog description, and add contact line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Prototype personal site for **Liat Moss**.
 - Main page background is white.
 - Hero text includes:
   - **Liat Moss**
-  - **C# Software Engineer**
+  - **Software engineer focused on practical AI tooling for engineering teams**
 - Below the header, there are two square thumbnail cards centred on the page with a 32px gap between them:
   - **About Me card**:
     - The card uses the profile image committed at `assets/about-me-thumbnail.png`
@@ -27,6 +27,7 @@ Prototype personal site for **Liat Moss**.
 - **About Me** heading sits inside the purple card, in the same purple colour as the career details line (`#3d3580`), and is the same size as the "Hi, I'm Liat Moss" text was before the update.
 - **Hi, I'm Liat Moss** heading is slightly larger than the About Me heading.
 - Career tagline reads: **Backend Engineer @ Prospa | C# and .NET coder | Develops with AI | Fuelled by coffee**
+- A contact line at the bottom of the card reads: **Contact me at liatmoss@hotmail.com** (same `about__body` styling as the body paragraphs).
 
 ## Blog Posts page
 
@@ -36,5 +37,6 @@ Prototype personal site for **Liat Moss**.
   - The card uses the image committed at `assets/blog-posts-thumbnail.png`.
   - A purple label box (background `#ece9ff`) sits at the top of the card with a link to the dev.to article.
   - Link text: **From Unknown to Understood: Navigating Codebases with GitHub Copilot**
+  - Description text (smaller, non-bold, below the link): *Navigating unfamiliar codebases using GitHub Copilot and custom agents to create structured understanding*
   - Link URL: `https://dev.to/liatmoss/from-unknown-to-understood-navigating-codebases-with-github-copilot-21dc`
   - The card (label + image together) is square (`350px × 350px`).

--- a/about.html
+++ b/about.html
@@ -23,6 +23,7 @@
           <p class="about__body">Liat Moss is a backend developer who writes code with C#/.NET and Azure, building APIs and systems designed to scale and last. She likes using AI tooling to learn new things and shares that knowledge with the engineering community.</p>
           <p class="about__body">She moved into software engineering in 2020 from a background in education and still enjoys using the skills from teaching to help educate others on what she's working on.</p>
           <p class="about__body">Outside of work, she enjoys getting hands on with technology which includes experimenting with microcontrollers and building LED wearables that respond to the environment.</p>
+          <p class="about__body">Contact me at liatmoss@hotmail.com</p>
         </div>
       </section>
     </main>

--- a/blog-posts.html
+++ b/blog-posts.html
@@ -19,6 +19,7 @@
         <div class="thumbnail-card">
           <div class="thumbnail-card__label">
             <a href="https://dev.to/liatmoss/from-unknown-to-understood-navigating-codebases-with-github-copilot-21dc" class="thumbnail-card__link" target="_blank" rel="noopener noreferrer">From Unknown to Understood: Navigating Codebases with GitHub Copilot</a>
+            <p class="thumbnail-card__description">Navigating unfamiliar codebases using GitHub Copilot and custom agents to create structured understanding</p>
           </div>
           <img src="assets/blog-posts-thumbnail.png" alt="Blog post illustration" class="thumbnail-card__image" />
         </div>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       <div class="hero__overlay"></div>
       <div class="hero__content">
         <h1 class="hero__heading">Liat Moss</h1>
-        <p class="hero__subtitle">C# Software Engineer</p>
+        <p class="hero__subtitle">Software engineer focused on practical AI tooling for engineering teams</p>
       </div>
     </header>
     <main>

--- a/styles.css
+++ b/styles.css
@@ -131,6 +131,13 @@ body {
   border-radius: 2px;
 }
 
+.thumbnail-card__description {
+  margin: 6px 0 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #3d3580;
+}
+
 .thumbnail-card__image {
   width: 100%;
   flex: 1;


### PR DESCRIPTION
## Changes

- **Homepage**: Updated hero subtitle from 'C# Software Engineer' to 'Software engineer focused on practical AI tooling for engineering teams'
- **Blog Posts page**: Added a smaller, non-bold description beneath the blog post title thumbnail link
- **About Me page**: Added a contact line ('Contact me at liatmoss@hotmail.com') below the last paragraph, using existing `about__body` styling
- **README**: Updated to reflect all three changes