### PR TITLE
Add dark mode with manual toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,7 +6,9 @@
     <title>About Me – Liat Moss</title>
     <script>
       try {
-        if (localStorage.getItem('theme') === 'dark')
+        const saved = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === 'dark' || (!saved && prefersDark))
           document.documentElement.setAttribute('data-theme', 'dark');
       } catch (_) {}
     </script>
@@ -15,7 +17,7 @@
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
-      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode">🌙</button>
       <div class="hero__content">
         <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
       </div>

--- a/about.html
+++ b/about.html
@@ -4,11 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About Me – Liat Moss</title>
+    <script>
+      try {
+        if (localStorage.getItem('theme') === 'dark')
+          document.documentElement.setAttribute('data-theme', 'dark');
+      } catch (_) {}
+    </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
       <div class="hero__content">
         <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
       </div>
@@ -28,5 +35,21 @@
       </section>
     </main>
     <footer class="site-footer">Page created by Liat Moss using Github Copilot CLI, Github Issues and Github Actions</footer>
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        try { localStorage.setItem('theme', isDark ? 'light' : 'dark'); } catch (_) {}
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '🌙' : '☀️';
+        btn.setAttribute('aria-label', isDark ? 'Switch to dark mode' : 'Switch to light mode');
+      }
+      (function () {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '☀️' : '🌙';
+        btn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      })();
+    </script>
   </body>
 </html>

--- a/blog-posts.html
+++ b/blog-posts.html
@@ -4,11 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blog Posts – Liat Moss</title>
+    <script>
+      try {
+        if (localStorage.getItem('theme') === 'dark')
+          document.documentElement.setAttribute('data-theme', 'dark');
+      } catch (_) {}
+    </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
       <div class="hero__content">
         <h1 class="hero__heading">Blog Posts</h1>
         <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
@@ -47,5 +54,21 @@
       </section>
     </main>
     <footer class="site-footer">Page created by Liat Moss using Github Copilot CLI, Github Issues and Github Actions</footer>
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        try { localStorage.setItem('theme', isDark ? 'light' : 'dark'); } catch (_) {}
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '🌙' : '☀️';
+        btn.setAttribute('aria-label', isDark ? 'Switch to dark mode' : 'Switch to light mode');
+      }
+      (function () {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '☀️' : '🌙';
+        btn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      })();
+    </script>
   </body>
 </html>

--- a/blog-posts.html
+++ b/blog-posts.html
@@ -6,7 +6,9 @@
     <title>Blog Posts – Liat Moss</title>
     <script>
       try {
-        if (localStorage.getItem('theme') === 'dark')
+        const saved = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === 'dark' || (!saved && prefersDark))
           document.documentElement.setAttribute('data-theme', 'dark');
       } catch (_) {}
     </script>
@@ -15,7 +17,7 @@
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
-      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode">🌙</button>
       <div class="hero__content">
         <h1 class="hero__heading">Blog Posts</h1>
         <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>

--- a/docs/superpowers/plans/2026-05-17-dark-mode.md
+++ b/docs/superpowers/plans/2026-05-17-dark-mode.md
@@ -1,0 +1,609 @@
+# Dark Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manually-toggled dark mode to liatmoss.github.io with preference persisted in localStorage.
+
+**Architecture:** CSS custom properties define the colour palette on `:root` (light) and `html[data-theme="dark"]` (dark). A tiny inline `<script>` in each `<head>` reads localStorage and sets the attribute before paint to prevent flash. A toggle button in the hero header calls a second inline script to flip the theme and persist the choice.
+
+**Tech Stack:** Vanilla HTML, CSS custom properties, vanilla JS (no framework, no build step)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `styles.css` | Add CSS variable blocks, replace hardcoded colours with `var()`, add `.hero__theme-toggle` styles |
+| `index.html` | Add init script, toggle button, toggle script |
+| `about.html` | Add init script, toggle button, toggle script |
+| `experience.html` | Add init script, toggle button, toggle script |
+| `blog-posts.html` | Add init script, toggle button, toggle script |
+
+---
+
+## Task 1: Update styles.css
+
+**Files:**
+- Modify: `styles.css`
+
+### Step 1.1: Add CSS variable blocks
+
+After the `*` reset block (after line 5), insert the `:root` light-mode variables and `html[data-theme="dark"]` dark-mode overrides:
+
+```css
+:root {
+  --bg: #ffffff;
+  --text: #05071f;
+  --accent: #3d3580;
+  --surface: #ece9ff;
+  --surface-text: #3d3580;
+  --surface-border: #d4cefc;
+  --text-secondary: #1a1a2e;
+}
+
+html[data-theme="dark"] {
+  --bg: #0d0f1e;
+  --text: #e8e9f5;
+  --accent: #a8b0ff;
+  --surface: #1a1d3a;
+  --surface-text: #a8b0ff;
+  --surface-border: #2d3060;
+  --text-secondary: #c8caf0;
+}
+```
+
+### Step 1.2: Update `body` colours
+
+Replace the two hardcoded values in the `body` rule:
+
+```css
+body {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+```
+
+### Step 1.3: Update thumbnail card colours
+
+Replace hardcoded colours in the thumbnail card rules:
+
+```css
+.thumbnail-card:focus-within {
+  box-shadow: 0 0 0 3px var(--accent);
+}
+
+.thumbnail-card__label {
+  background: var(--surface);
+  padding: 16px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.thumbnail-card__link {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--surface-text);
+  text-decoration: none;
+}
+
+.thumbnail-card__link:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.thumbnail-card__description {
+  margin: 6px 0 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--surface-text);
+}
+```
+
+### Step 1.4: Update about page colours
+
+```css
+.about__heading {
+  margin: 0 0 16px;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.about__card {
+  background: var(--surface);
+  border-radius: 16px;
+  padding: 36px 40px;
+  color: var(--text);
+}
+
+.about__tagline {
+  margin: 0 0 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--surface-text);
+}
+
+.about__body {
+  margin: 0 0 16px;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+```
+
+### Step 1.5: Update experience page colours
+
+```css
+.experience__summary {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent);
+  cursor: pointer;
+  list-style: none;
+  padding: 8px 0;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.experience__summary:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+```
+
+### Step 1.6: Update footer colours
+
+```css
+.site-footer {
+  text-align: center;
+  padding: 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--surface-text);
+  background: var(--surface);
+  border-top: 1px solid var(--surface-border);
+}
+```
+
+### Step 1.7: Add `.hero__theme-toggle` styles
+
+Add this block after the `.hero__button:focus-visible` rule (keep near existing hero button styles):
+
+```css
+.hero__theme-toggle {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 999px;
+  color: #ffffff;
+  font-size: 1.25rem;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.hero__theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.hero__theme-toggle:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 2px;
+}
+```
+
+### Step 1.8: Verify
+
+Open `index.html` directly in a browser (double-click the file or use `open index.html`).
+
+Expected: page looks identical to before (light mode is default). No colours should have changed.
+
+- [ ] Step 1.1: Add CSS variable blocks
+- [ ] Step 1.2: Update `body` colours
+- [ ] Step 1.3: Update thumbnail card colours
+- [ ] Step 1.4: Update about page colours
+- [ ] Step 1.5: Update experience page colours
+- [ ] Step 1.6: Update footer colours
+- [ ] Step 1.7: Add `.hero__theme-toggle` styles
+- [ ] Step 1.8: Verify page looks unchanged in browser
+
+### Step 1.9: Commit
+
+```bash
+git add styles.css
+git commit -m "feat: add CSS custom properties and dark theme colour overrides"
+```
+
+- [ ] Step 1.9: Commit
+
+---
+
+## Task 2: Update index.html
+
+**Files:**
+- Modify: `index.html`
+
+### Step 2.1: Add theme init script to `<head>`
+
+Insert the following **immediately before** `<link rel="stylesheet" href="styles.css" />` in `<head>`:
+
+```html
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+```
+
+The `<head>` block should now look like:
+
+```html
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Liat Moss</title>
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+```
+
+### Step 2.2: Add toggle button to hero
+
+Insert the button **immediately after** `<div class="hero__overlay"></div>` and **before** `<div class="hero__content">`:
+
+```html
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+```
+
+The hero block should now look like:
+
+```html
+    <header class="hero">
+      <div class="hero__overlay"></div>
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+      <div class="hero__content">
+        <h1 class="hero__heading">Liat Moss</h1>
+        <p class="hero__subtitle">Software engineer focused on practical AI tooling for engineering teams</p>
+      </div>
+    </header>
+```
+
+### Step 2.3: Add toggle script before `</body>`
+
+Insert the following immediately before `</body>`:
+
+```html
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        localStorage.setItem('theme', isDark ? 'light' : 'dark');
+        document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+      }
+      document.getElementById('theme-toggle').textContent =
+        document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+    </script>
+```
+
+### Step 2.4: Verify
+
+Open `index.html` in a browser.
+
+Expected:
+- A 🌙 button appears in the top-right corner of the hero
+- Clicking it switches the page to dark mode (dark navy background, light text, dark card colours) and the button changes to ☀️
+- Clicking again reverts to light mode
+- Refreshing the page with dark mode active keeps dark mode (emoji shows ☀️ immediately, no flash)
+
+- [ ] Step 2.1: Add init script to `<head>`
+- [ ] Step 2.2: Add toggle button to hero
+- [ ] Step 2.3: Add toggle script before `</body>`
+- [ ] Step 2.4: Verify toggle, persistence, and no flash in browser
+
+### Step 2.5: Commit
+
+```bash
+git add index.html
+git commit -m "feat: add dark mode toggle to index.html"
+```
+
+- [ ] Step 2.5: Commit
+
+---
+
+## Task 3: Update about.html
+
+**Files:**
+- Modify: `about.html`
+
+### Step 3.1: Add theme init script to `<head>`
+
+Insert immediately before `<link rel="stylesheet" href="styles.css" />`:
+
+```html
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+```
+
+The `<head>` block should now look like:
+
+```html
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Me – Liat Moss</title>
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+```
+
+### Step 3.2: Add toggle button to hero
+
+Insert immediately after `<div class="hero__overlay"></div>`:
+
+```html
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+```
+
+The hero block should now look like:
+
+```html
+    <header class="hero">
+      <div class="hero__overlay"></div>
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+      <div class="hero__content">
+        <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
+      </div>
+    </header>
+```
+
+### Step 3.3: Add toggle script before `</body>`
+
+Insert immediately before `</body>`:
+
+```html
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        localStorage.setItem('theme', isDark ? 'light' : 'dark');
+        document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+      }
+      document.getElementById('theme-toggle').textContent =
+        document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+    </script>
+```
+
+### Step 3.4: Verify
+
+Open `about.html` in a browser.
+
+Expected:
+- Toggle button appears in the hero top-right
+- Setting dark mode on `index.html`, then navigating to `about.html`, loads in dark mode immediately (no flash)
+- Toggle works on this page independently
+
+- [ ] Step 3.1: Add init script to `<head>`
+- [ ] Step 3.2: Add toggle button to hero
+- [ ] Step 3.3: Add toggle script before `</body>`
+- [ ] Step 3.4: Verify theme persists from index.html and toggle works
+
+### Step 3.5: Commit
+
+```bash
+git add about.html
+git commit -m "feat: add dark mode toggle to about.html"
+```
+
+- [ ] Step 3.5: Commit
+
+---
+
+## Task 4: Update experience.html
+
+**Files:**
+- Modify: `experience.html`
+
+### Step 4.1: Add theme init script to `<head>`
+
+Insert immediately before `<link rel="stylesheet" href="styles.css" />`:
+
+```html
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+```
+
+The `<head>` block should now look like:
+
+```html
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Experience – Liat Moss</title>
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+```
+
+### Step 4.2: Add toggle button to hero
+
+Insert immediately after `<div class="hero__overlay"></div>`:
+
+```html
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+```
+
+The hero block should now look like:
+
+```html
+    <header class="hero">
+      <div class="hero__overlay"></div>
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+      <div class="hero__content">
+        <h1 class="hero__heading">Experience</h1>
+        <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
+      </div>
+    </header>
+```
+
+### Step 4.3: Add toggle script before `</body>`
+
+Insert immediately before `</body>`:
+
+```html
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        localStorage.setItem('theme', isDark ? 'light' : 'dark');
+        document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+      }
+      document.getElementById('theme-toggle').textContent =
+        document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+    </script>
+```
+
+### Step 4.4: Verify
+
+Open `experience.html` in a browser.
+
+Expected:
+- Toggle button appears in the hero top-right
+- Theme persists when navigating from other pages
+- The collapsible experience sections render correctly in both light and dark mode
+
+- [ ] Step 4.1: Add init script to `<head>`
+- [ ] Step 4.2: Add toggle button to hero
+- [ ] Step 4.3: Add toggle script before `</body>`
+- [ ] Step 4.4: Verify theme persists and collapsible sections look correct in both modes
+
+### Step 4.5: Commit
+
+```bash
+git add experience.html
+git commit -m "feat: add dark mode toggle to experience.html"
+```
+
+- [ ] Step 4.5: Commit
+
+---
+
+## Task 5: Update blog-posts.html
+
+**Files:**
+- Modify: `blog-posts.html`
+
+### Step 5.1: Add theme init script to `<head>`
+
+Insert immediately before `<link rel="stylesheet" href="styles.css" />`:
+
+```html
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+```
+
+The `<head>` block should now look like:
+
+```html
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog Posts – Liat Moss</title>
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+```
+
+### Step 5.2: Add toggle button to hero
+
+Insert immediately after `<div class="hero__overlay"></div>`:
+
+```html
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+```
+
+The hero block should now look like:
+
+```html
+    <header class="hero">
+      <div class="hero__overlay"></div>
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+      <div class="hero__content">
+        <h1 class="hero__heading">Blog Posts</h1>
+        <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
+      </div>
+    </header>
+```
+
+### Step 5.3: Add toggle script before `</body>`
+
+Insert immediately before `</body>`:
+
+```html
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        localStorage.setItem('theme', isDark ? 'light' : 'dark');
+        document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+      }
+      document.getElementById('theme-toggle').textContent =
+        document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+    </script>
+```
+
+### Step 5.4: Verify
+
+Open `blog-posts.html` in a browser.
+
+Expected:
+- Toggle button appears in the hero top-right
+- Theme persists when navigating from other pages
+- All four blog post thumbnail cards render correctly in both light and dark mode (dark surface background, correct accent link colours)
+
+- [ ] Step 5.1: Add init script to `<head>`
+- [ ] Step 5.2: Add toggle button to hero
+- [ ] Step 5.3: Add toggle script before `</body>`
+- [ ] Step 5.4: Verify theme persists and all blog post cards look correct in both modes
+
+### Step 5.5: Commit
+
+```bash
+git add blog-posts.html
+git commit -m "feat: add dark mode toggle to blog-posts.html"
+```
+
+- [ ] Step 5.5: Commit

--- a/docs/superpowers/specs/2026-05-17-dark-mode-design.md
+++ b/docs/superpowers/specs/2026-05-17-dark-mode-design.md
@@ -1,0 +1,87 @@
+# Dark Mode Design
+
+**Date:** 2026-05-17
+**Status:** Approved
+
+## Overview
+
+Add a manually-toggled dark mode to liatmoss.github.io. The user's preference is persisted in `localStorage` so it is remembered across page navigations and return visits.
+
+## Color Palette
+
+All hardcoded color values in `styles.css` are replaced with CSS custom properties. Light mode is the default; dark overrides are applied when `html[data-theme="dark"]` is set.
+
+| Role | CSS Variable | Light | Dark |
+|---|---|---|---|
+| Page background | `--bg` | `#ffffff` | `#0d0f1e` |
+| Body text | `--text` | `#05071f` | `#e8e9f5` |
+| Accent (headings, links) | `--accent` | `#3d3580` | `#a8b0ff` |
+| Surface (cards, footer bg) | `--surface` | `#ece9ff` | `#1a1d3a` |
+| Surface text | `--surface-text` | `#3d3580` | `#a8b0ff` |
+| Surface border | `--surface-border` | `#d4cefc` | `#2d3060` |
+| Secondary body text | `--text-secondary` | `#1a1a2e` | `#c8caf0` |
+
+The hero section uses a fixed dark navy background with an overlay image — it looks identical in both modes and requires no variable changes.
+
+## Architecture
+
+### CSS
+
+`styles.css` is updated in two places:
+
+1. A `:root` block defines the light-mode CSS variables.
+2. An `html[data-theme="dark"]` block overrides them with dark-mode values.
+3. All hardcoded color values throughout the file are replaced with `var(--variable-name)`.
+
+### Theme initialisation (per HTML file, in `<head>`)
+
+A small inline `<script>` is placed in `<head>` **before** the `<link rel="stylesheet">` tag. It reads `localStorage` and sets `data-theme` on `<html>` before the browser renders anything, preventing a flash of the wrong theme during page load.
+
+```html
+<script>
+  if (localStorage.getItem('theme') === 'dark')
+    document.documentElement.setAttribute('data-theme', 'dark');
+</script>
+```
+
+This script is added to all 4 HTML files: `index.html`, `about.html`, `experience.html`, `blog-posts.html`.
+
+### Toggle logic (per HTML file, end of `<body>`)
+
+A second inline `<script>` at the bottom of `<body>` defines the toggle function and initialises the button label on load:
+
+```js
+function toggleTheme() {
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+  localStorage.setItem('theme', isDark ? 'light' : 'dark');
+  document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+}
+document.getElementById('theme-toggle').textContent =
+  document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+```
+
+## Toggle Button
+
+A button is added to the hero markup on all 4 pages, positioned absolutely in the top-right corner of the `.hero` section:
+
+```html
+<button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+```
+
+Styling (added to `styles.css`):
+
+- Positioned `absolute`, `top: 16px`, `right: 16px`
+- Small transparent pill with a white border, matching the existing `.hero__button` aesthetic
+- Font size `1.25rem` to make the emoji legible
+- Focus ring for accessibility
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `styles.css` | Add CSS variables, dark theme overrides, `.hero__theme-toggle` styles |
+| `index.html` | Add init script in `<head>`, toggle button in hero, toggle script in `<body>` |
+| `about.html` | Same as above |
+| `experience.html` | Same as above |
+| `blog-posts.html` | Same as above |

--- a/experience.html
+++ b/experience.html
@@ -4,11 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Experience – Liat Moss</title>
+    <script>
+      try {
+        if (localStorage.getItem('theme') === 'dark')
+          document.documentElement.setAttribute('data-theme', 'dark');
+      } catch (_) {}
+    </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
       <div class="hero__content">
         <h1 class="hero__heading">Experience</h1>
         <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>
@@ -44,5 +51,21 @@
       </section>
     </main>
     <footer class="site-footer">Page created by Liat Moss using Github Copilot CLI, Github Issues and Github Actions</footer>
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        try { localStorage.setItem('theme', isDark ? 'light' : 'dark'); } catch (_) {}
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '🌙' : '☀️';
+        btn.setAttribute('aria-label', isDark ? 'Switch to dark mode' : 'Switch to light mode');
+      }
+      (function () {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '☀️' : '🌙';
+        btn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      })();
+    </script>
   </body>
 </html>

--- a/experience.html
+++ b/experience.html
@@ -6,7 +6,9 @@
     <title>Experience – Liat Moss</title>
     <script>
       try {
-        if (localStorage.getItem('theme') === 'dark')
+        const saved = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === 'dark' || (!saved && prefersDark))
           document.documentElement.setAttribute('data-theme', 'dark');
       } catch (_) {}
     </script>
@@ -15,7 +17,7 @@
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
-      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode">🌙</button>
       <div class="hero__content">
         <h1 class="hero__heading">Experience</h1>
         <a href="index.html" class="hero__button hero__button--back" aria-label="Return to home page">Back to Main Page</a>

--- a/index.html
+++ b/index.html
@@ -5,15 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Liat Moss</title>
     <script>
-      if (localStorage.getItem('theme') === 'dark')
-        document.documentElement.setAttribute('data-theme', 'dark');
+      try {
+        if (localStorage.getItem('theme') === 'dark')
+          document.documentElement.setAttribute('data-theme', 'dark');
+      } catch (_) {}
     </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
-      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
       <div class="hero__content">
         <h1 class="hero__heading">Liat Moss</h1>
         <p class="hero__subtitle">Software engineer focused on practical AI tooling for engineering teams</p>
@@ -46,11 +48,17 @@
       function toggleTheme() {
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
         document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
-        localStorage.setItem('theme', isDark ? 'light' : 'dark');
-        document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+        try { localStorage.setItem('theme', isDark ? 'light' : 'dark'); } catch (_) {}
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '🌙' : '☀️';
+        btn.setAttribute('aria-label', isDark ? 'Switch to dark mode' : 'Switch to light mode');
       }
-      document.getElementById('theme-toggle').textContent =
-        document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+      (function () {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const btn = document.getElementById('theme-toggle');
+        btn.textContent = isDark ? '☀️' : '🌙';
+        btn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      })();
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <title>Liat Moss</title>
     <script>
       try {
-        if (localStorage.getItem('theme') === 'dark')
+        const saved = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === 'dark' || (!saved && prefersDark))
           document.documentElement.setAttribute('data-theme', 'dark');
       } catch (_) {}
     </script>
@@ -15,7 +17,7 @@
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
-      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode"></button>
+      <button id="theme-toggle" type="button" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode">🌙</button>
       <div class="hero__content">
         <h1 class="hero__heading">Liat Moss</h1>
         <p class="hero__subtitle">Software engineer focused on practical AI tooling for engineering teams</p>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Liat Moss</title>
+    <script>
+      if (localStorage.getItem('theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <header class="hero">
       <div class="hero__overlay"></div>
+      <button id="theme-toggle" class="hero__theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
       <div class="hero__content">
         <h1 class="hero__heading">Liat Moss</h1>
         <p class="hero__subtitle">Software engineer focused on practical AI tooling for engineering teams</p>
@@ -37,5 +42,15 @@
       </section>
     </main>
     <footer class="site-footer">Page created by Liat Moss using Github Copilot CLI, Github Issues and Github Actions</footer>
+    <script>
+      function toggleTheme() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+        localStorage.setItem('theme', isDark ? 'light' : 'dark');
+        document.getElementById('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+      }
+      document.getElementById('theme-toggle').textContent =
+        document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+    </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,7 @@ body {
 
 .hero__theme-toggle {
   position: absolute;
+  z-index: 1;
   top: 16px;
   right: 16px;
   background: transparent;

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
   --text: #05071f;
   --accent: #3d3580;
   --surface: #ece9ff;
-  --surface-text: #3d3580;
+  --surface-text: #3d3580; /* intentionally matches --accent; kept separate in case surface tones diverge */
   --surface-border: #d4cefc;
   --text-secondary: #1a1a2e;
 }

--- a/styles.css
+++ b/styles.css
@@ -4,11 +4,31 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg: #ffffff;
+  --text: #05071f;
+  --accent: #3d3580;
+  --surface: #ece9ff;
+  --surface-text: #3d3580;
+  --surface-border: #d4cefc;
+  --text-secondary: #1a1a2e;
+}
+
+html[data-theme="dark"] {
+  --bg: #0d0f1e;
+  --text: #e8e9f5;
+  --accent: #a8b0ff;
+  --surface: #1a1d3a;
+  --surface-text: #a8b0ff;
+  --surface-border: #2d3060;
+  --text-secondary: #c8caf0;
+}
+
 body {
   margin: 0;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background: #ffffff;
-  color: #05071f;
+  background: var(--bg);
+  color: var(--text);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -79,6 +99,33 @@ body {
   outline-offset: 2px;
 }
 
+.hero__theme-toggle {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 999px;
+  color: #ffffff;
+  font-size: 1.25rem;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.hero__theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.hero__theme-toggle:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 2px;
+}
+
 .hero__button--back {
   text-decoration: none;
   display: inline-block;
@@ -110,10 +157,11 @@ body {
 }
 
 .thumbnail-card:focus-within {
-  box-shadow: 0 0 0 3px #3d3580;
+  box-shadow: 0 0 0 3px var(--accent);
 }
+
 .thumbnail-card__label {
-  background: #ece9ff;
+  background: var(--surface);
   padding: 16px;
   text-align: center;
   flex-shrink: 0;
@@ -122,7 +170,7 @@ body {
 .thumbnail-card__link {
   font-size: 1rem;
   font-weight: 600;
-  color: #3d3580;
+  color: var(--surface-text);
   text-decoration: none;
 }
 
@@ -131,7 +179,7 @@ body {
 }
 
 .thumbnail-card__link:focus-visible {
-  outline: 3px solid #3d3580;
+  outline: 3px solid var(--accent);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -140,7 +188,7 @@ body {
   margin: 6px 0 0;
   font-size: 0.875rem;
   font-weight: 400;
-  color: #3d3580;
+  color: var(--surface-text);
 }
 
 .thumbnail-card__image {
@@ -163,14 +211,14 @@ body {
   margin: 0 0 16px;
   font-size: clamp(1.25rem, 3vw, 1.75rem);
   font-weight: 700;
-  color: #3d3580;
+  color: var(--accent);
 }
 
 .about__card {
-  background: #ece9ff;
+  background: var(--surface);
   border-radius: 16px;
   padding: 36px 40px;
-  color: #05071f;
+  color: var(--text);
 }
 
 .about__name {
@@ -183,14 +231,14 @@ body {
   margin: 0 0 24px;
   font-size: 1rem;
   font-weight: 600;
-  color: #3d3580;
+  color: var(--surface-text);
 }
 
 .about__body {
   margin: 0 0 16px;
   font-size: 1rem;
   line-height: 1.7;
-  color: #1a1a2e;
+  color: var(--text-secondary);
 }
 
 .about__body:last-child {
@@ -210,7 +258,7 @@ body {
 .experience__summary {
   font-size: 1rem;
   font-weight: 600;
-  color: #3d3580;
+  color: var(--accent);
   cursor: pointer;
   list-style: none;
   padding: 8px 0;
@@ -243,7 +291,7 @@ body {
 }
 
 .experience__summary:focus-visible {
-  outline: 3px solid #3d3580;
+  outline: 3px solid var(--accent);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -263,7 +311,7 @@ main {
   padding: 24px;
   font-size: 1rem;
   font-weight: 600;
-  color: #3d3580;
-  background: #ece9ff;
-  border-top: 1px solid #d4cefc;
+  color: var(--surface-text);
+  background: var(--surface);
+  border-top: 1px solid var(--surface-border);
 }


### PR DESCRIPTION
## Summary

- Adds CSS custom properties for a complete light/dark colour palette, replacing all hardcoded colours in `styles.css`
- Adds a 🌙/☀️ toggle button in the hero header on all four pages, persisting preference in `localStorage`
- Init script in each `<head>` applies saved theme (or OS preference on first visit) before the stylesheet loads, preventing any flash of the wrong theme

## Test Plan

- [ ] Open the site in a browser and confirm light mode loads by default
- [ ] Click the toggle — confirm the page switches to dark mode and the button changes to ☀️
- [ ] Refresh — confirm dark mode persists (no flash)
- [ ] Navigate between all four pages — confirm theme is consistent across index, about, experience, and blog posts
- [ ] Set OS to dark mode with no saved preference — confirm site opens in dark mode on first visit
- [ ] Confirm the toggle button is visible and keyboard-focusable in the hero on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)