### PR TITLE
Improve homepage card layout with CSS Grid

### DIFF
--- a/blog-posts.html
+++ b/blog-posts.html
@@ -24,7 +24,7 @@
       </div>
     </header>
     <main>
-      <section class="thumbnails thumbnails--blog">
+      <section class="thumbnails">
         <div class="thumbnail-card">
           <div class="thumbnail-card__label">
             <a href="https://dev.to/liatmoss/from-unknown-to-understood-navigating-codebases-with-github-copilot-21dc" class="thumbnail-card__link" target="_blank" rel="noopener noreferrer">From Unknown to Understood: Navigating Codebases with GitHub Copilot</a>

--- a/docs/superpowers/plans/2026-05-17-homepage-card-layout.md
+++ b/docs/superpowers/plans/2026-05-17-homepage-card-layout.md
@@ -1,0 +1,133 @@
+# Homepage Card Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the fixed-width flex card layout on the homepage with a responsive CSS grid that scales gracefully as more cards are added.
+
+**Architecture:** Two CSS rules change in `styles.css` (`.thumbnails` switches from flex to grid; `.thumbnail-card` loses its fixed width) and one class is removed from the homepage section element in `index.html`. No new files, no structural HTML changes, no JS changes.
+
+**Tech Stack:** Vanilla HTML, CSS Grid (no build step)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `styles.css` | Replace flex with grid on `.thumbnails`; remove `width: 350px` from `.thumbnail-card` |
+| `index.html` | Remove `thumbnails--blog` class from the `<section>` element |
+
+---
+
+## Task 1: Update styles.css
+
+**Files:**
+- Modify: `styles.css`
+
+### Step 1.1: Replace flex with grid on `.thumbnails`
+
+Find the `.thumbnails` rule (currently around line 137) and replace the three flex properties with a grid declaration:
+
+```css
+.thumbnails {
+  max-width: 1200px;
+  margin: 48px auto;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 32px;
+}
+```
+
+Remove these three lines:
+- `display: flex;`
+- `flex-wrap: wrap;`
+- `justify-content: center;`
+
+Add these two lines:
+- `display: grid;`
+- `grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));`
+
+(`gap: 32px` already exists and stays unchanged.)
+
+### Step 1.2: Remove fixed width from `.thumbnail-card`
+
+Find the `.thumbnail-card` rule (currently around line 151) and remove the `width: 350px` line. The rule should become:
+
+```css
+.thumbnail-card {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 12px;
+}
+```
+
+### Step 1.3: Verify in browser
+
+Open `index.html` directly in a browser (`open index.html`).
+
+Expected:
+- The three cards fill the available width in a row (not centred with space on the sides)
+- Resizing the window narrows cards gracefully — no horizontal scroll, no mid-word wrapping
+- Cards remain square (aspect-ratio still applied)
+
+- [ ] Step 1.1: Replace flex with grid on `.thumbnails`
+- [ ] Step 1.2: Remove `width: 350px` from `.thumbnail-card`
+- [ ] Step 1.3: Verify layout in browser
+
+### Step 1.4: Commit
+
+```bash
+git add styles.css
+git commit -m "feat: switch thumbnail grid from flex to CSS grid"
+```
+
+- [ ] Step 1.4: Commit
+
+---
+
+## Task 2: Update index.html
+
+**Files:**
+- Modify: `index.html`
+
+### Step 2.1: Remove `thumbnails--blog` class from homepage section
+
+Find the section element in `index.html` (currently around line 18):
+
+```html
+<section class="thumbnails thumbnails--blog">
+```
+
+Change it to:
+
+```html
+<section class="thumbnails">
+```
+
+`thumbnails--blog` sets `max-width: 780px`, which was incorrectly limiting the homepage grid to ~2 columns. Removing it lets the homepage use the full 1200px container width. The class stays in `blog-posts.html` where it belongs.
+
+### Step 2.2: Verify in browser
+
+Open `index.html` in a browser and resize the window.
+
+Expected:
+- At wide viewport (>1200px): cards fill a centred 1200px-wide grid
+- At ~900px: 3 columns
+- At ~600px: 2 columns
+- At ~400px: 1 column
+- No layout difference between dark and light mode
+
+- [ ] Step 2.1: Remove `thumbnails--blog` from `index.html`
+- [ ] Step 2.2: Verify responsive behaviour across viewport widths
+
+### Step 2.3: Commit
+
+```bash
+git add index.html
+git commit -m "fix: remove incorrect thumbnails--blog constraint from homepage"
+```
+
+- [ ] Step 2.3: Commit

--- a/docs/superpowers/specs/2026-05-17-homepage-card-layout-design.md
+++ b/docs/superpowers/specs/2026-05-17-homepage-card-layout-design.md
@@ -1,0 +1,74 @@
+# Homepage Card Layout Design
+
+**Date:** 2026-05-17
+**Status:** Approved
+
+## Problem
+
+The homepage thumbnail cards use a fixed `350px` width inside a flexbox container. This causes two issues:
+1. Card text wraps mid-word when the label is longer than the fixed card width allows
+2. The layout does not scale gracefully as more cards are added — flex-wrap produces uneven last rows and the `thumbnails--blog` max-width cap (780px) limits the grid to ~2 columns
+
+## Goal
+
+Replace the fixed-width flex layout with a CSS grid that adapts to any number of cards, gives text room to breathe, and works correctly from mobile up to wide desktop.
+
+## Design
+
+### Layout (styles.css)
+
+**`.thumbnails`** — switch from flexbox to CSS grid:
+
+```css
+.thumbnails {
+  max-width: 1200px;
+  margin: 48px auto;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 32px;
+}
+```
+
+- `justify-content: center` is removed — no longer needed; grid fills its container naturally
+- Column count is viewport-driven: ~4 at 1200px, 3 at 900px, 2 at 600px, 1 at 400px
+- No explicit media queries required
+
+**`.thumbnail-card`** — remove `width: 350px`:
+
+```css
+.thumbnail-card {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 12px;
+}
+```
+
+Grid columns control card width. `aspect-ratio: 1/1` is retained so cards stay square at any column width. All other rules (image, label, link) are unchanged.
+
+### HTML (index.html)
+
+Remove the `thumbnails--blog` modifier from the homepage section:
+
+```html
+<!-- before -->
+<section class="thumbnails thumbnails--blog">
+
+<!-- after -->
+<section class="thumbnails">
+```
+
+`thumbnails--blog` (which sets `max-width: 780px`) remains in use on `blog-posts.html` only. The homepage uses the standard `.thumbnails` max-width of 1200px.
+
+### Card structure
+
+No changes. Label on top, image below — existing structure is retained.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `styles.css` | `.thumbnails`: replace flex with grid, remove `justify-content`. `.thumbnail-card`: remove `width: 350px` |
+| `index.html` | Remove `thumbnails--blog` class from the section element |

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       </div>
     </header>
     <main>
-      <section class="thumbnails thumbnails--blog">
+      <section class="thumbnails">
         <div class="thumbnail-card">
           <div class="thumbnail-card__label">
             <a href="about.html" class="thumbnail-card__link">About Me</a>

--- a/styles.css
+++ b/styles.css
@@ -143,10 +143,6 @@ body {
   gap: 32px;
 }
 
-.thumbnails--blog {
-  max-width: 780px;
-}
-
 .thumbnail-card {
   aspect-ratio: 1 / 1;
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -138,9 +138,8 @@ body {
   max-width: 1200px;
   margin: 48px auto;
   padding: 0 24px;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 32px;
 }
 
@@ -149,7 +148,6 @@ body {
 }
 
 .thumbnail-card {
-  width: 350px;
   aspect-ratio: 1 / 1;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Replaces the fixed-width flexbox card layout with a responsive CSS grid (`repeat(auto-fill, minmax(280px, 1fr))`) across all pages that use cards
- Removes the fixed `width: 350px` from `.thumbnail-card` — grid columns now control card sizing
- Removes the incorrect `thumbnails--blog` class from both `index.html` and `blog-posts.html` (that class was capping the grid to 780px, limiting it to ~2 columns)
- Deletes the now-unused `.thumbnails--blog` CSS rule

## Test Plan

- [ ] Cards fill the full container width across all viewport sizes on both the homepage and blog posts page
- [ ] Resizing the window wraps cards cleanly without mid-word text breaks
- [ ] At ~900px: 3 columns; at ~600px: 2 columns; at ~400px: 1 column
- [ ] Dark mode toggle still works correctly on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)